### PR TITLE
Remove deprecated MPI call

### DIFF
--- a/src/main/cons2prim.f90
+++ b/src/main/cons2prim.f90
@@ -157,7 +157,7 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
  use part,              only:isdead_or_accreted,massoftype,igas,rhoh,igasP,iradP,iradxi,ics,&
                              iohm,ihall,nden_nimhd,eta_nimhd,iambi,get_partinfo,iphase,this_is_a_test,&
                              ndustsmall,itemp,ikappa
- use eos,               only:equationofstate,ieos,gamma,get_temperature,done_init_eos,init_eos
+ use eos,               only:equationofstate,ieos,get_temperature,done_init_eos,init_eos
  use radiation_utils,   only:radiation_equation_of_state,get_opacity
  use dim,               only:store_temperature,store_gamma,mhd,maxvxyzu,maxphase,maxp,use_dustgrowth,&
                              do_radiation,nalpha,mhd_nonideal
@@ -165,8 +165,6 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
  use io,                only:fatal,real4
  use cullendehnen,      only:get_alphaloc,xi_limiter
  use options,           only:alpha,alphamax,use_dustfrac,iopacity_type
- use units,             only:unit_density,unit_opacity
-
  integer,      intent(in)    :: npart
  real,         intent(in)    :: xyzh(:,:),rad(:,:),gamma_chem(:),Bevol(:,:),dustevol(:,:)
  real(kind=4), intent(in)    :: dvdx(:,:)
@@ -175,7 +173,7 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
  real,         intent(out)   :: eos_vars(:,:),radprop(:,:),Bxyz(:,:),dustfrac(:,:)
  integer      :: i,iamtypei,ierr
  integer      :: ierrlist(n_warn)
- real         :: rhoi,pondens,spsound,p_on_rhogas,rhogas,gasfrac,pmassi
+ real         :: rhoi,spsound,p_on_rhogas,rhogas,gasfrac,pmassi
  real         :: Bxi,Byi,Bzi,psii,xi_limiteri,Bi,temperaturei
  real         :: xi,yi,zi,hi
  logical      :: iactivei,iamgasi,iamdusti
@@ -192,11 +190,11 @@ subroutine cons2prim_everything(npart,xyzh,vxyzu,dvdx,rad,eos_vars,radprop,&
 
 !$omp parallel do default (none) &
 !$omp shared(xyzh,vxyzu,npart,rad,eos_vars,radprop,Bevol,Bxyz) &
-!$omp shared(ieos,gamma,gamma_chem,nden_nimhd,eta_nimhd) &
+!$omp shared(ieos,gamma_chem,nden_nimhd,eta_nimhd) &
 !$omp shared(alpha,alphamax,iphase,maxphase,maxp,massoftype) &
 !$omp shared(use_dustfrac,dustfrac,dustevol,this_is_a_test,ndustsmall,alphaind,dvdx) &
-!$omp shared(unit_density,unit_opacity,iopacity_type) &
-!$omp private(i,spsound,pondens,rhoi,p_on_rhogas,rhogas,gasfrac) &
+!$omp shared(iopacity_type) &
+!$omp private(i,spsound,rhoi,p_on_rhogas,rhogas,gasfrac) &
 !$omp private(Bxi,Byi,Bzi,psii,xi_limiteri,Bi,temperaturei,ierr,pmassi) &
 !$omp private(xi,yi,zi,hi) &
 !$omp firstprivate(iactivei,iamtypei,iamgasi,iamdusti) &

--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -157,7 +157,7 @@ subroutine get_mpitype_of_kdnode(dtype)
  disp(nblock) = addr - start
 #endif
 
- call MPI_TYPE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
+ call MPI_TYPE_CREATE_STRUCT(nblock,blens(1:nblock),disp(1:nblock),mpitypes(1:nblock),dtype,mpierr)
  call MPI_TYPE_COMMIT(dtype,mpierr)
 
  ! check extent okay

--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -85,7 +85,7 @@ subroutine get_mpitype_of_kdnode(dtype)
  integer, intent(out)            :: dtype
  integer                         :: dtype_old
  integer                         :: nblock, blens(ndata), mpitypes(ndata)
- integer(kind=4)                 :: disp(ndata)
+ integer(kind=MPI_ADDRESS_KIND)  :: disp(ndata)
 
  type(kdnode)                    :: node
  integer(kind=MPI_ADDRESS_KIND)  :: addr,start,lb,extent

--- a/src/main/dtype_kdtree.F90
+++ b/src/main/dtype_kdtree.F90
@@ -79,6 +79,7 @@ contains
 subroutine get_mpitype_of_kdnode(dtype)
  use mpi
  use mpiutils, only:mpierr
+ use io,       only:error
 
  integer, parameter              :: ndata = 20
 
@@ -163,12 +164,7 @@ subroutine get_mpitype_of_kdnode(dtype)
  ! check extent okay
  call MPI_TYPE_GET_EXTENT(dtype,lb,extent,mpierr)
  if (extent /= sizeof(node)) then
-    dtype_old = dtype
-    lb = 0
-    extent = sizeof(node)
-    call MPI_TYPE_CREATE_RESIZED(dtype_old,lb,extent,dtype,mpierr)
-    call MPI_TYPE_COMMIT(dtype,mpierr)
-    call MPI_TYPE_FREE(dtype_old,mpierr)
+    call error('dtype_kdtree','MPI_TYPE_GET_EXTENT has calculated the extent incorrectly')
  endif
 
 end subroutine get_mpitype_of_kdnode

--- a/src/tests/test_cooling.f90
+++ b/src/tests/test_cooling.f90
@@ -20,7 +20,7 @@ module testcooling
  use testutils, only:checkval,update_test_scores
  use io,        only:id,master
  implicit none
- public :: test_cooling
+ public :: test_cooling, test_cooling_rate
 
  private
 
@@ -61,7 +61,7 @@ subroutine test_cooling_rate(ntests,npass)
  use physcon,   only:Rg,mass_proton_cgs
  use units,     only:unit_ergg,unit_density,udist,utime
  real :: abundance(nabundances)
- real :: ratesq(nrates)
+ !real :: ratesq(nrates)
  integer, intent(inout) :: ntests,npass
  integer, parameter :: nt = 400
  real :: logtmin,logtmax,logt,dlogt,t,crate

--- a/src/tests/test_luminosity.F90
+++ b/src/tests/test_luminosity.F90
@@ -57,8 +57,10 @@ subroutine test_lum(ntests,npass)
  real                   :: time
  real(kind=4) :: t1,t2
  integer                :: nfail(1),ii
-#endif
+#ifdef IND_TIMESTEPS
  integer :: nactive
+#endif
+#endif
 
 !#ifdef DISC_VISCOSITY
 !    if (id==master) write(*,"(/,a)") '--> SKIPPING TEST OF LIGHTCURVE (cannot have -DDISC_VISCOSITY)'


### PR DESCRIPTION
Replace MPI_TYPE_STRUCT with MPI_TYPE_CREATE_STRUCT.

Throw error if extent is calculated incorrectly